### PR TITLE
[DON'T MERGE] feat(counter): custom default; set_num; no overflow

### DIFF
--- a/contracts/counter/Cargo.toml
+++ b/contracts/counter/Cargo.toml
@@ -11,7 +11,7 @@ crate-type = ["cdylib"]
 near-sdk = "4.0.0"
 
 [profile.dev]
-overflow-checks = false # default: true; see https://doc.rust-lang.org/cargo/reference/profiles.html#dev
+overflow-checks = true
 
 [profile.release]
 codegen-units = 1
@@ -19,4 +19,4 @@ opt-level = "z"
 lto = true
 debug = false
 panic = "abort"
-overflow-checks = false # default: false; see https://doc.rust-lang.org/cargo/reference/profiles.html#release
+overflow-checks = true

--- a/contracts/counter/src/lib.rs
+++ b/contracts/counter/src/lib.rs
@@ -6,9 +6,15 @@ use near_sdk::borsh::{self, BorshDeserialize, BorshSerialize};
 use near_sdk::{log, near_bindgen};
 
 #[near_bindgen]
-#[derive(Default, BorshDeserialize, BorshSerialize)]
+#[derive(BorshDeserialize, BorshSerialize)]
 pub struct Counter {
     val: i8,
+}
+
+impl Default for Counter {
+    fn default() -> Self {
+        Self { val: 127 }
+    }
 }
 
 #[near_bindgen]
@@ -29,6 +35,13 @@ impl Counter {
     pub fn decrement(&mut self) -> i8 {
         self.val -= 1;
         log!("Decreased number to {}", self.val);
+        self.val
+    }
+
+    /// Public method: Set the counter.
+    pub fn set_num(&mut self, num: i8) -> i8 {
+        self.val = num;
+        log!("Set number to {}", num);
         self.val
     }
 }
@@ -56,5 +69,19 @@ mod tests {
         let mut contract = Counter { val: 0 };
         contract.decrement();
         assert_eq!(-1, contract.get_num());
+    }
+
+    #[test]
+    #[should_panic]
+    fn panics_on_overflow() {
+        let mut contract = Counter { val: 127 };
+        contract.increment();
+    }
+
+    #[test]
+    #[should_panic]
+    fn panics_on_underflow() {
+        let mut contract = Counter { val: -128 };
+        contract.decrement();
     }
 }


### PR DESCRIPTION
This is meant to be a long-lived branch that people can reference when going through [raen.dev/guide](https://raen.dev/guide). **Don't merge; don't delete branch.** Someday when `raendev/examples` is structured as a Rust project with no submodules, this will be one of its member projects, alongside the simpler counter. (Prerequisite for this work: make a `raen dev-deploy` that wraps `near dev-deploy` that automatically deploys multiple contracts to subaccounts of the dev account or a single contract to the root dev account, maintaining parity with current `dev-deploy`.)

Simple improvements for the counter:

- custom default: show the sort of code that `#[derive(Default)]` adds;
  add a different default
- `set_num`: new change method
- no overflow: prevent overflows using `overflow-checks = true`. If
  `val` is currently `127` and someone calls `increment`, this prevents
  it from overflowing to `-128`. It also prevents a counter at `-128`
  from underflowing to `127`. If contract doesn't check itself, this can
  be super important when dealing with financial contracts.